### PR TITLE
update initialOptions to $watchCollection

### DIFF
--- a/src/ionic-modal-select.js
+++ b/src/ionic-modal-select.js
@@ -111,7 +111,7 @@
                             );
 
                         } else {
-                            scope.$watch('initialOptions', function(nv){
+                            scope.$watchCollection('initialOptions', function(nv){
                                 initialOptionsSetup(nv);
                                 updateListMode();
                             });


### PR DESCRIPTION
Fix for issue: https://github.com/inmagik/ionic-modal-select/issues/49

Based on : http://stackoverflow.com/questions/15363259/watch-not-being-triggered-on-array-change

> By default, $watch does not check for object equality, but just for reference. So, $watch('tasks', ...) will always simply return the same array reference, which isn't changing.

Angular v1.1.4 adds a $watchCollection() method to handle this case:

> Shallow watches the properties of an object and fires whenever any of the properties change (for arrays this implies watching the array items, for object maps this implies watching the properties). If a change is detected the listener callback is fired.